### PR TITLE
Let Travis construct as much of the matrix as possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,16 @@ addons:
       - tk-dev
       - liblzma-dev
       - python-pip
+
+compiler:
+  - clang
+  - gcc
+
+env:
+  - TESTING=cpython
       
 matrix:
   include:
-    - os: linux
-      compiler: gcc
-      env: TESTING=cpython
-    - os: linux
-      compiler: clang
-      env: TESTING=cpython
     - os: linux
       language: python
       python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,44 @@
 language: c
+
 # For doc-building dependencies.
 cache: pip
-  
+
 addons:
   apt:
     packages:
       - tk-dev
       - liblzma-dev
       - python-pip
-
+      
 compiler:
   - clang
   - gcc
 
 env:
-  - TESTING=cpython
-      
+  - PYTHON=python
+
 matrix:
   include:
+    - os: osx
+      compiler: clang  # gcc is just a symlink for clang on macOS.
+      env:
+        - PYTHON=python.exe
     - os: linux
       language: python
       python: 3.5
-      env: TESTING=docs
+      before_script:
+        - cd Doc
+        - make venv PYTHON=python3
+      script:
+        - make html SPHINXBUILD="./venv/bin/python3 -m sphinx" SPHINXOPTS="-nW -q -b linkcheck"
+
+# Travis provides only 2 cores.
+before_script:
+  - ./configure --with-pydebug
+  - make -j4
 
 script:
-  - if [[ "$TESTING" == "cpython" ]]; then ./configure --with-pydebug && make -j && ./python -bb -E -W default -m test -r -w -uall -j0 ; fi
-  - if [[ "$TESTING" == "docs" ]]; then cd Doc && make venv PYTHON=python3 && make html SPHINXBUILD="./venv/bin/python3 -m sphinx" SPHINXOPTS="-nW -q -b linkcheck" ; fi
+  - ./$PYTHON -bb -E -W default -m test -r -w -uall -j4
 
 notifications:
   email: false


### PR DESCRIPTION
Instead of manually defining our matrix, let Travis construct
it for us other than a manual inclusion for the docs. This will
make it easier to add new things to the matrix (such as, macOS
testing) without having to spell out every item in the matrix.